### PR TITLE
Reimplement components with Bootstrap 4 and add Material Icons

### DIFF
--- a/ckan-widget/package-lock.json
+++ b/ckan-widget/package-lock.json
@@ -6788,6 +6788,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "material-icons": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-0.2.3.tgz",
+      "integrity": "sha512-1Q5wp4aeGWjE5POMtdLmqJn94QM7vmUCeJhNO5m0oDrtW1jfWlaLK73vF3C7/fuMD7NIVicyK8TSkwd+diFgaQ=="
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",

--- a/ckan-widget/package.json
+++ b/ckan-widget/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "bootstrap": "^4.1.3",
+    "material-icons": "^0.2.3",
     "react": "^16.4.2",
     "react-autocomplete": "^1.8.1",
     "react-dom": "^16.4.2",

--- a/ckan-widget/public/index.html
+++ b/ckan-widget/public/index.html
@@ -25,7 +25,11 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
-    <div id="root"></div>
+    <div class="container-fluid my-5">
+      <div class="col-lg-10 offset-lg-1">
+        <div id="root"></div>
+      </div>
+    </div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/ckan-widget/src/App.css
+++ b/ckan-widget/src/App.css
@@ -1,69 +1,21 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
-  height: 80px;
-}
-
-.App-header {
-  background-color: #222;
-  height: 150px;
-  padding: 20px;
-  color: white;
-}
-
-.App-title {
-  font-size: 1.5em;
-}
-
-.App-intro {
-  font-size: large;
-}
-
-@keyframes App-logo-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-.dataset-item {
-  border: 1px solid #c4c4c4;
-  padding: 10px 20px;
-  margin: 24px 0;
-  display:flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.dataset-body {
-    margin: 0 20px;
-  flex-grow: 1;
-  h2 {
-    margin-bottom: 0;
-  }
-}
-.dataset-icon{
-    max-width: 100%;
-    height: auto;
-    vertical-align: middle;
-    border: 0;
-}
 .facet-item {
   border: 2px solid #c4c4c4;
   padding: 10px 20px;
   margin: 10px 0;
-  display:flex;
+  display: flex;
   align-items: center;
   justify-content: space-between;
 }
-.datasets-total{
-    float:left;
+
+.datasets-total {
+  float: left;
 }
-.search-item {
-  border: 2px solid #c4c4c4;
-  padding: 30px 20px;
-  margin: 10px 0;
-  display:flex;
-  align-items: center;
-  justify-content: space-between;
+
+.menu {
+  margin: .75rem auto;
+  text-align: left;
+}
+
+.material-icons {
+  vertical-align: middle;
 }

--- a/ckan-widget/src/App.js
+++ b/ckan-widget/src/App.js
@@ -10,14 +10,18 @@ class App extends Component {
   render() {
     return (
       <div className="App container-fluid">
-        <DatasetSearchBar />
         <div className="row">
-          <div className="col-md-8">
-            <DatasetInfoList />
+          <div className="col-lg-8">
+            <DatasetSearchBar />
           </div>
-          <div className="col-md-4">
-            <DatasetSort />
-            <FacetList />
+        </div>
+        <div className="row">
+          <div className="col-lg-8">
+                <DatasetInfoList />
+          </div>
+          <div className="col-lg-4">
+              <DatasetSort />
+              <FacetList />
           </div>
         </div>
       </div>

--- a/ckan-widget/src/components/presentational/DatasetDetails.js
+++ b/ckan-widget/src/components/presentational/DatasetDetails.js
@@ -38,7 +38,7 @@ class DatasetDetails extends Component {
         const collapseClass = collapsed ? 'collapse' : ''
 
         return(
-            <div className={"dataset-body " + collapseClass}>
+            <div className={"card-footer " + collapseClass}>
                 <p>{notes}</p>
                 <p>Created on: {dataset_creation_date}</p>
                 <p>Publication date: {dataset_publication_date}</p>

--- a/ckan-widget/src/components/presentational/DatasetInfo.js
+++ b/ckan-widget/src/components/presentational/DatasetInfo.js
@@ -37,15 +37,21 @@ class DatasetInfo extends Component{
         const datetime = this.formatDate(metadata_modified)
         const formats = this.findFormats(resources)
         return(
-            <div>
-                <div className="dataset-item" onClick={this.handleDatasetClick}>
-                    <img className="dataset-icon" src="https://www.datasud.fr/wp-content/themes/crigepaca/assets/images/logo_region_paca.jpg" alt="Description" />
-                    <div className="dataset-body">
-                        <h2 onClick={this.handleDatasetClick}>{title}</h2>
-                        <span>{notes.length > 130 ? `${notes.substring(0, 130)}...` : notes}</span>
-                        <p>Modified: {datetime}</p>
-                        <p>Formats: {formats !== undefined ? formats.join(', ') : 'N/A'}</p>
-                        <p>Datatype: {datatype !== undefined ? datatype.join(', ') : 'N/A'}</p>
+            <div className="card my-3">
+                <div className="card-body" onClick={this.handleDatasetClick}>
+                    <div className="row">
+                        <div className="col-lg-3 d-flex justify-content-center align-items-center">
+                            <img className="img-thumbnail img-fluid" src="https://www.datasud.fr/wp-content/themes/crigepaca/assets/images/logo_region_paca.jpg" alt="logo" />
+                        </div>
+                        <div className="col-lg-9">
+                            <h3><a href="#" onClick={this.handleDatasetClick}>{title}</a></h3>
+                            <p className="text-muted">{notes.length > 130 ? `${notes.substring(0, 130)}...` : notes}</p>
+                            <ul className="list-inline">
+                              <li className="list-inline-item">Modified: {datetime}</li>
+                              <li className="list-inline-item">Formats: {formats !== undefined ? formats.join(', ') : 'N/A'}</li>
+                              <li className="list-inline-item">Datatype: {datatype !== undefined ? datatype.join(', ') : 'N/A'}</li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
                 <DatasetDetails collapsed={this.state.collapsed} {...this.props} />

--- a/ckan-widget/src/components/presentational/DatasetsPerPage.js
+++ b/ckan-widget/src/components/presentational/DatasetsPerPage.js
@@ -7,14 +7,18 @@ class DatasetsPerPage extends Component {
 
   render() {
     return (
-      <div className="datasets-per-page">
-        <label>Datasets per page: </label>
-        <select value={this.props.rows} onChange={this.handleOnChange}>
-          <option value='10'>10</option>
-          <option value='25'>25</option>
-          <option value='50'>50</option>
-          <option value='100'>100</option>
-        </select>
+      <div className="">
+          <div className="input-group">
+              <div className="input-group-prepend">
+                <label for="datasets_per_page" className="input-group-text">Datasets per page: </label>
+              </div>
+              <select id="datasets_per_page" className="custom-select" value={this.props.rows} onChange={this.handleOnChange}>
+                <option value='10'>10</option>
+                <option value='25'>25</option>
+                <option value='50'>50</option>
+                <option value='100'>100</option>
+              </select>
+          </div>
       </div>
     )
   }

--- a/ckan-widget/src/components/presentational/SearchBar.js
+++ b/ckan-widget/src/components/presentational/SearchBar.js
@@ -40,13 +40,14 @@ class SearchBar extends Component{
 
     render(){
         return(
-            <form className="search-item" onSubmit={this.handleOnSubmit}>
+            <form className="my-5" onSubmit={this.handleOnSubmit}>
                 <Autocomplete
                     inputProps={{
                         id: 'datasets-autocomplete',
-                        placeholder: 'Search datasets'
+                        placeholder: 'Search datasets',
+                        className: 'form-control form-control-lg'
                     }}
-                    wrapperStyle={{ position: 'relative', display: 'inline-block' }}l
+                    wrapperStyle={{}}
                     value={this.state.value}
                     items={this.state.suggestions}
                     open={( this.state.value.length >= 1 && this.state.isOpen )}
@@ -59,13 +60,13 @@ class SearchBar extends Component{
                     }}
                     onChange={this.handleOnChange}
                     renderMenu={children => (
-                        <div className="menu">
+                        <div className="menu list-group">
                             {children}
                         </div>
                     )}
                     renderItem={(item, isHighlighted) => (
-                        <div className={`item ${isHighlighted ? 'item-highlighted' : ''}`} key={item.match_displayed}>
-                            {item.match_displayed}
+                        <div className={`list-group-item list-group-item-light ${isHighlighted ? 'active' : ''}`} key={item.match_displayed}>
+                            <i class="material-icons mr-1">library_books</i> {item.match_displayed}
                         </div>
                     )}
                 />

--- a/ckan-widget/src/components/presentational/Sort.js
+++ b/ckan-widget/src/components/presentational/Sort.js
@@ -3,8 +3,11 @@ import React, { Component } from 'react';
 class Sort extends Component {
   render() {
     return (
-      <div className="dropdown">
-        <select value={this.props.sort} onChange={e => this.props.handleSort(e.target.value)}>
+      <div className="input-group">
+        <div className="input-group-prepend">
+            <label for="datasets_per_page" className="input-group-text">Order by:</label>
+        </div>
+        <select className="custom-select" value={this.props.sort} onChange={e => this.props.handleSort(e.target.value)}>
           <option value="score desc, metadata_modified desc">Relevance</option>
           <option value="title_string asc">Name Ascending</option>
           <option value="title_string desc">Name Descending</option>

--- a/ckan-widget/src/components/presentational/TotalDatasets.js
+++ b/ckan-widget/src/components/presentational/TotalDatasets.js
@@ -5,14 +5,16 @@ class TotalDatasets extends Component {
     const { total } = this.props;
     const resultName = (total === 1) ? 'result' : 'results';
 
-    return (
-      <div className="datasets-total">
-        {total}
-        {' '}
-        {resultName}
+    return(
+      <div className="">
+          <h2>
+              {total}
+              {' '}
+              {resultName}
+          </h2>
       </div>
-    );
+    )
   }
 }
 
-export default TotalDatasets;
+export default TotalDatasets

--- a/ckan-widget/src/index.css
+++ b/ckan-widget/src/index.css
@@ -1,5 +1,4 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: sans-serif;
 }

--- a/ckan-widget/src/index.js
+++ b/ckan-widget/src/index.js
@@ -8,6 +8,7 @@ import registerServiceWorker from './registerServiceWorker';
 import App from './App';
 import reducers from './reducers';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import 'material-icons/iconfont/material-icons.css';
 
 const createStoreWithMiddleware = applyMiddleware(thunk)(createStore);
 const store = createStoreWithMiddleware(reducers);


### PR DESCRIPTION
This PR reimplements components with Bootstrap 4 - adds or modifies markup - removes non-used CSS and adds Material Icons.